### PR TITLE
#19 Rev to dotnet 1.1

### DIFF
--- a/app/templates/_gitignore
+++ b/app/templates/_gitignore
@@ -12,6 +12,7 @@ local.ecosystem.json
 *.sublime-project
 *.sublime-workspace
 .tmp/
+.vscode/
 
 ## MGM Pulling in a sample .gitignore for a ASP.NET Core project
 

--- a/app/templates/project.json
+++ b/app/templates/project.json
@@ -9,44 +9,39 @@
     "dependencies": {
         "Microsoft.NETCore.App": {
             "type": "platform",
-            "version": "1.0.1"
+            "version": "1.1.0"
         },
-        "Microsoft.AspNetCore.Diagnostics": "1.0.0",
-        "Microsoft.AspNetCore.Mvc": "1.0.1",
-        "Microsoft.AspNetCore.Server.IISIntegration": "1.0.0",
-        "Microsoft.AspNetCore.Server.Kestrel": "1.0.1",
-        "Microsoft.AspNetCore.StaticFiles": "1.0.0",
-        "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.0.0",
-        "Microsoft.Extensions.Configuration.Json": "1.0.0",
-        "Microsoft.Extensions.Logging": "1.0.0",
-        "Microsoft.Extensions.Logging.Console": "1.0.0",
-        "Microsoft.Extensions.Logging.Debug": "1.0.0",
-        "Microsoft.AspNetCore.Mvc.Formatters.Json": "1.0.1",
-        "Microsoft.AspNetCore.Routing": "1.0.1",
-        "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
-        "Microsoft.AspNetCore.Proxy": "0.1.0"
+        "Microsoft.AspNetCore.Diagnostics": "1.1.0",
+        "Microsoft.AspNetCore.Mvc": "1.1.0",
+        "Microsoft.AspNetCore.Server.IISIntegration": "1.1.0",
+        "Microsoft.AspNetCore.Server.Kestrel": "1.1.0",
+        "Microsoft.AspNetCore.StaticFiles": "1.1.0",
+        "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.0",
+        "Microsoft.Extensions.Configuration.Json": "1.1.0",
+        "Microsoft.Extensions.Logging": "1.1.0",
+        "Microsoft.Extensions.Logging.Console": "1.1.0",
+        "Microsoft.Extensions.Logging.Debug": "1.1.0",
+        "Microsoft.AspNetCore.Mvc.Formatters.Json": "1.1.0",
+        "Microsoft.AspNetCore.Routing": "1.1.0",
+        "Microsoft.Extensions.Options.ConfigurationExtensions": "1.1.0",
+        "Microsoft.AspNetCore.Proxy": "0.2.0"
     },
     "tools": {
-        "Microsoft.AspNetCore.Server.IISIntegration.Tools": {
-            "version": "1.0.0-preview1-final",
-            "imports": "portable-net45+wp80+win8+wpa81+dnxcore50"
-        },
-        "Microsoft.DotNet.Watcher.Tools": {
-            "version": "1.0.0-*",
-            "imports": "portable-net451+win8"
-        }
+        "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.1.0-preview4-final"
     },
+
     "frameworks": {
-        "netcoreapp1.0": {
-            "imports": [
-                "portable-net45+wp80+win8+wpa81+dnxcore50",
-                "dnxcore50",
-                "portable-net451+win8"
-            ]
-        }
+      "netcoreapp1.1": {
+        "imports": [
+            "dotnet5.6",
+            "portable-net45+win8"
+        ]
+      }
     },
     "runtimeOptions": {
-        "gcServer": true
+        "configProperties": {
+        "System.GC.Server": true
+        }
     },
     "publishOptions": {
         "include": [


### PR DESCRIPTION
Visual Studio code now leaves behind a .vscode directory.  Add this to the upgrade as well.